### PR TITLE
Use constant Charnock parameter in Moon formulation for z0

### DIFF
--- a/gsmphys/sfc_diff_gfdl.f
+++ b/gsmphys/sfc_diff_gfdl.f
@@ -292,7 +292,7 @@
             ! option 4: Moon et al 2007 under high winds (same as in HiRAM)
                ws10m_moon = 2.458 + ustar(i)*(20.255-0.56*ustar(i))  ! Eq(7) Moon et al. 2007 
                if ( ws10m_moon > 20. ) then
-                  call cal_z0_moon(ws10m_moon, z0, charnock(i))
+                  call cal_z0_moon(ws10m_moon, z0)
                   z0 = max(min(z0, z0s_max), 1.e-7) ! must apply limiter here
                endif
             endif
@@ -481,7 +481,7 @@
 
 ! =======================================================================
 
-      subroutine cal_z0_moon(ws10m, z0, charnock)
+      subroutine cal_z0_moon(ws10m, z0M)
       ! coded by Kun Gao (Kun.Gao@noaa.gov)
       use machine , only : kind_phys
       use physcons, grav => con_g
@@ -490,7 +490,7 @@
       real(kind=kind_phys) :: ustar_th, z0_adj 
 
       real(kind=kind_phys), parameter ::
-!     &          charnock=.014
+     &          charnock=.014
      &          wind_th_moon = 20. 
      &,         a = 0.56
      &,         b = -20.255

--- a/gsmphys/sfc_diff_gfdl.f
+++ b/gsmphys/sfc_diff_gfdl.f
@@ -481,7 +481,7 @@
 
 ! =======================================================================
 
-      subroutine cal_z0_moon(ws10m, z0M)
+      subroutine cal_z0_moon(ws10m, z0)
       ! coded by Kun Gao (Kun.Gao@noaa.gov)
       use machine , only : kind_phys
       use physcons, grav => con_g


### PR DESCRIPTION
**Description**

The Moon paper develops a wind-speed based empirical formulation of roughness length for atmosphere-only simulations. The formulation uses a constant value of the Charnock parameter. 

That empirical formulation is already mimicking results from wave-atmosphere coupled simulations, and is a fit using that constant value. Using a deviation from Charnock (as a result from our coupling) would alter the results and create a fit different to the Moon paper. 

Note: 
This branch is a feature on top of[ this branch](https://github.com/wavespotter/GFDL_atmos_cubed_sphere/tree/wolfgang/rebase_sofar-071124_on_main), which is our current dev branch rebased onto main


**How Has This Been Tested?**

Not yet.

**Checklist:**

Please check all whether they apply or not
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
