### PR TITLE
Move diagnostics from sfc_diff to sfc_diag

### DIFF
--- a/GFS_layer/GFS_physics_driver.F90
+++ b/GFS_layer/GFS_physics_driver.F90
@@ -479,7 +479,7 @@ module module_physics_driver
            doms, psautco_l, prautco_l, ocalnirbm_cpl, ocalnirdf_cpl,    &
            ocalvisbm_cpl, ocalvisdf_cpl, dtzm, temrain1, t2mmp, q2mp,   &
            !--  For coupling with wave model                              ! Sofar added 10/20/23
-           fm10_neutral, fm_neutral,                                    & ! Sofar added 10/20/23
+           fm10_neutral,                                                & ! Sofar added 10/20/23
            !--- coupling inputs for physics
            dtsfc_cice, dqsfc_cice, dusfc_cice, dvsfc_cice, ulwsfc_cice, &
            tisfc_cice, tsea_cice, hice_cice, fice_cice,                 &
@@ -1216,7 +1216,7 @@ module module_physics_driver
                  Sfcprop%ffmm,  Sfcprop%ffhh,                       &
                  Sfcprop%charnock,                                  &  
                  Sfcprop%rhoa,                                      &                
-                 fm10_neutral, fm_neutral,                          &  
+                 fm10_neutral,                                      &  
                  Sfcprop%uustar,                                    &
                  wind,  Tbd%phy_f2d(1,Model%num_p2d), fm10, fh2,    &
                  sigmaf, vegtype, Sfcprop%shdmax, Model%ivegsrc,    &
@@ -1519,7 +1519,7 @@ module module_physics_driver
               Sfcprop%t2m, Sfcprop%q2m, work3, evap,           &
               Sfcprop%ffmm, Sfcprop%ffhh, fm10, fh2, &
               Sfcprop%u10m, Sfcprop%v10m,&
-              fm10_neutral, fm_neutral, Diag%u10n, Diag%v10n, &
+              fm10_neutral, Diag%u10n, Diag%v10n, &
               Sfcprop%u10n, Sfcprop%v10n)  
       !endif
 
@@ -3876,7 +3876,7 @@ module module_physics_driver
                        Sfcprop%q2m, work3, evap, Sfcprop%ffmm,          &
                        Sfcprop%ffhh, fm10, fh2, &
                        Sfcprop%u10m, Sfcprop%v10m,&
-                       fm10_neutral, fm_neutral, Diag%u10n, Diag%v10n, &
+                       fm10_neutral, Diag%u10n, Diag%v10n, &
                        Sfcprop%u10n, Sfcprop%v10n)  
 
         if (Model%lssav) then

--- a/GFS_layer/GFS_physics_driver.F90
+++ b/GFS_layer/GFS_physics_driver.F90
@@ -479,7 +479,7 @@ module module_physics_driver
            doms, psautco_l, prautco_l, ocalnirbm_cpl, ocalnirdf_cpl,    &
            ocalvisbm_cpl, ocalvisdf_cpl, dtzm, temrain1, t2mmp, q2mp,   &
            !--  For coupling with wave model                              ! Sofar added 10/20/23
-           fm10_neutral,                                                & ! Sofar added 10/20/23
+           fm10_neutral, fm_neutral,                                    & ! Sofar added 10/20/23
            !--- coupling inputs for physics
            dtsfc_cice, dqsfc_cice, dusfc_cice, dvsfc_cice, ulwsfc_cice, &
            tisfc_cice, tsea_cice, hice_cice, fice_cice,                 &
@@ -1214,11 +1214,9 @@ module module_physics_driver
                  Sfcprop%tsfc, Sfcprop%zorl, Sfcprop%ztrl, cd,      &
                  cdq, rb, Statein%prsl(1,1), work3, islmsk, stress, &
                  Sfcprop%ffmm,  Sfcprop%ffhh,                       &
-                 Sfcprop%charnock,                                  &  ! Sofar added Spring 2023
-                 Sfcprop%rhoa,                                      &  ! Sofar added 9/22/23
-                 Sfcprop%u10m, Sfcprop%v10m,                        &  ! Sofar added 11/17/23
-                 Sfcprop%u10n, Sfcprop%v10n,                        &  ! Sofar added 9/22/23
-                 fm10_neutral,                                      &  ! Sofar added 10/19/23
+                 Sfcprop%charnock,                                  &  
+                 Sfcprop%rhoa,                                      &                
+                 fm10_neutral, fm_neutral,                          &  
                  Sfcprop%uustar,                                    &
                  wind,  Tbd%phy_f2d(1,Model%num_p2d), fm10, fh2,    &
                  sigmaf, vegtype, Sfcprop%shdmax, Model%ivegsrc,    &
@@ -1520,7 +1518,9 @@ module module_physics_driver
               Sfcprop%f10m, Diag%u10m, Diag%v10m,        &
               Sfcprop%t2m, Sfcprop%q2m, work3, evap,           &
               Sfcprop%ffmm, Sfcprop%ffhh, fm10, fh2, &
-              fm10_neutral, Diag%u10n, Diag%v10n)  ! Added by Sofar: 10/19/23
+              Sfcprop%u10m, Sfcprop%v10m,&
+              fm10_neutral, fm_neutral, Diag%u10n, Diag%v10n, &
+              Sfcprop%u10n, Sfcprop%v10n)  
       !endif
 
       Tbd%phy_f2d(:,Model%num_p2d) = 0.0
@@ -3875,7 +3875,9 @@ module module_physics_driver
                        Sfcprop%f10m, Diag%u10m, Diag%v10m, Sfcprop%t2m, &
                        Sfcprop%q2m, work3, evap, Sfcprop%ffmm,          &
                        Sfcprop%ffhh, fm10, fh2, &
-                       fm10_neutral, Diag%u10n, Diag%v10n)  ! Added by Sofar: 10/19/23
+                       Sfcprop%u10m, Sfcprop%v10m,&
+                       fm10_neutral, fm_neutral, Diag%u10n, Diag%v10n, &
+                       Sfcprop%u10n, Sfcprop%v10n)  
 
         if (Model%lssav) then
           Diag%tmpmax (:) = max(Diag%tmpmax (:),Sfcprop%t2m(:))

--- a/gsmphys/sfc_diag.f
+++ b/gsmphys/sfc_diag.f
@@ -1,7 +1,9 @@
       subroutine sfc_diag(im,ps,u1,v1,t1,q1,
      &                    tskin,qsurf,f10m,u10m,v10m,t2m,q2m,
      &                    prslki,evap,fm,fh,fm10,fh2,
-     &                    fm10_neutral,u10n,v10n)    ! Sofar added: 10/19/23
+     &                    sfc_u10m,sfc_v10m,
+     &                    fm10_neutral,fm_neutral, u10n,v10n,
+     &                    sfc_u10n, sfc_v10n)
 !
       use machine , only : kind_phys
       use funcphys, only : fpvs
@@ -13,7 +15,8 @@
       real, dimension(im) :: ps,   u1,   v1,   t1,  q1,  tskin,  qsurf,
      &                       f10m, u10m, v10m, t2m, q2m, prslki, evap,
      &                       fm,   fh,   fm10, fh2, 
-     &                       fm10_neutral, u10n, v10n    ! Added by Sofar: 10/19/23
+     &                       fm10_neutral, fm_neutral, u10n, v10n,
+     &                       sfc_u10n, sfc_v10n, sfc_u10m, sfc_v10m 
 !
 !     locals
 !
@@ -38,10 +41,12 @@
 !       f10m(i) = min(f10m(i),1.)
         u10m(i) = f10m(i) * u1(i)
         v10m(i) = f10m(i) * v1(i)
-        ! Sofar - start
-        u10n(i) = u1(i) * fm10_neutral(i) / fm(i)
-        v10n(i) = v1(i) * fm10_neutral(i) / fm(i)
-        ! Sofar - end
+        sfc_u10m(i) = u10m(i)
+        sfc_v10m(i) = v10m(i)
+        u10n(i) = u1(i) * fm10_neutral(i) / fm_neutral(i)
+        v10n(i) = v1(i) * fm10_neutral(i) / fm_neutral(i)
+        sfc_u10n(i) = u10n(i)
+        sfc_v10n(i) = v10n(i)
         fhi     = fh2(i) / fh(i)
 !       t2m(i)  = tskin(i)*(1. - fhi) + t1(i) * prslki(i) * fhi
 !       sig2k   = 1. - (grav+grav) / (cp * t2m(i))

--- a/gsmphys/sfc_diag.f
+++ b/gsmphys/sfc_diag.f
@@ -2,7 +2,7 @@
      &                    tskin,qsurf,f10m,u10m,v10m,t2m,q2m,
      &                    prslki,evap,fm,fh,fm10,fh2,
      &                    sfc_u10m,sfc_v10m,
-     &                    fm10_neutral,fm_neutral, u10n,v10n,
+     &                    fm10_neutral u10n,v10n,
      &                    sfc_u10n, sfc_v10n)
 !
       use machine , only : kind_phys
@@ -15,7 +15,7 @@
       real, dimension(im) :: ps,   u1,   v1,   t1,  q1,  tskin,  qsurf,
      &                       f10m, u10m, v10m, t2m, q2m, prslki, evap,
      &                       fm,   fh,   fm10, fh2, 
-     &                       fm10_neutral, fm_neutral, u10n, v10n,
+     &                       fm10_neutral, u10n, v10n,
      &                       sfc_u10n, sfc_v10n, sfc_u10m, sfc_v10m 
 !
 !     locals
@@ -43,8 +43,8 @@
         v10m(i) = f10m(i) * v1(i)
         sfc_u10m(i) = u10m(i)
         sfc_v10m(i) = v10m(i)
-        u10n(i) = u1(i) * fm10_neutral(i) / fm_neutral(i)
-        v10n(i) = v1(i) * fm10_neutral(i) / fm_neutral(i)
+        u10n(i) = u1(i) * fm10_neutral(i) / fm(i)
+        v10n(i) = v1(i) * fm10_neutral(i) / fm(i)
         sfc_u10n(i) = u10n(i)
         sfc_v10n(i) = v10n(i)
         fhi     = fh2(i) / fh(i)

--- a/gsmphys/sfc_diff_gfdl.f
+++ b/gsmphys/sfc_diff_gfdl.f
@@ -12,11 +12,9 @@
      &                    snwdph,tskin,z0rl,ztrl,cm,ch,rb,
      &                    prsl1,prslki,islimsk,
      &                    stress,fm,fh,
-     &                    charnock,                             ! Sofar added Spring 2023
-     &                    rhoa,                                 ! Sofar added 9/22/23
-     &                    u10m_array,v10m_array,                ! Sofar added 11/17/23
-     &                    u10n,v10n,                            ! Sofar added 9/22/23
-     &                    fm10_neutral,                         ! Sofar added 10/19/23
+     &                    charnock,                             
+     &                    rhoa,                                 
+     &                    fm10_neutral, fm_neutral,                
      &                    ustar,wind,ddvel,fm10,fh2,
      &                    sigmaf,vegtype,shdmax,ivegsrc,
      &                    tsurf,flag_iter,redrag,
@@ -43,13 +41,12 @@
      &,                                    prsl1, prslki, stress
      &,                                    fm, fh
      &,                                    charnock                     ! Sofar added Spring 2023
-     &,                                    rhoa, u10n, v10n             ! Sofar added 9/22/23
-     &,                                    u10m_array, v10m_array       ! Sofar added 11/17/23
+     &,                                    rhoa
      &,                                    ustar, wind 
      &,                                    ddvel
      &,                                    fm10, fh2, sigmaf, shdmax
      &,                                    tsurf, snwdph
-     &,                                    fm_neutral, fm10_neutral     ! Sofar added Spring 2023
+     &,                                    fm_neutral, fm10_neutral   
       real(kind=kind_phys) :: ws1, ws10n                                ! Sofar added 10/19/23
       integer, dimension(im)             ::vegtype, islimsk
 
@@ -256,14 +253,6 @@
 !           ! Convert to components  by making use of the wind direction from the lowest model level
 !           u10n = (u1(i) / ws1) * ws10n
 !           v10n = (v1(i) / ws1) * ws10n
-
-            ! Compute neutral winds for output to Sfcprop
-            u10n(i) = u1(i) * fm10_neutral(i) / fm(i) 
-            v10n(i) = v1(i) * fm10_neutral(i) / fm(i)
-
-            ! Compute standard 10m winds for output to Sfcprop
-            u10m_array(i) = u1(i) * fm10(i) / fm(i)
-            v10m_array(i) = v1(i) * fm10(i) / fm(i)
 
             ! ---------------------------------------------- - Sofar (end)
               

--- a/gsmphys/sfc_diff_gfdl.f
+++ b/gsmphys/sfc_diff_gfdl.f
@@ -14,7 +14,7 @@
      &                    stress,fm,fh,
      &                    charnock,                             
      &                    rhoa,                                 
-     &                    fm10_neutral, fm_neutral,                
+     &                    fm10_neutral,               
      &                    ustar,wind,ddvel,fm10,fh2,
      &                    sigmaf,vegtype,shdmax,ivegsrc,
      &                    tsurf,flag_iter,redrag,


### PR DESCRIPTION
**Description**

This moves the computation of surface diagnostics into the sfc_diag subroutine. This routine is used to provide 10 m winds and 10-m neutral winds. Originally, winds were computed in sfc_diff and stored in sfcprop thereby using not the final similar functions. With this PR the 10-m winds in sfcprop will be computed in sfc_diag using the correct final similarity functions. The winds are thus identical to those used for diagnostic purposes.


Fixes # (issue)

**How Has This Been Tested?**

Not yet.

**Checklist:**

Please check all whether they apply or not
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
