### PR TITLE
Compute air density for coupling with wave model at the 2-m level

### DIFF
--- a/GFS_layer/GFS_physics_driver.F90
+++ b/GFS_layer/GFS_physics_driver.F90
@@ -1215,7 +1215,6 @@ module module_physics_driver
                  cdq, rb, Statein%prsl(1,1), work3, islmsk, stress, &
                  Sfcprop%ffmm,  Sfcprop%ffhh,                       &
                  Sfcprop%charnock,                                  &  ! Sofar added Spring 2023
-                 Sfcprop%rhoa,                                      &  ! Sofar added 9/22/23
                  Sfcprop%u10m, Sfcprop%v10m,                        &  ! Sofar added 11/17/23
                  Sfcprop%u10n, Sfcprop%v10n,                        &  ! Sofar added 9/22/23
                  fm10_neutral,                                      &  ! Sofar added 10/19/23
@@ -1520,7 +1519,7 @@ module module_physics_driver
               Sfcprop%f10m, Diag%u10m, Diag%v10m,        &
               Sfcprop%t2m, Sfcprop%q2m, work3, evap,           &
               Sfcprop%ffmm, Sfcprop%ffhh, fm10, fh2, &
-              fm10_neutral, Diag%u10n, Diag%v10n)  ! Added by Sofar: 10/19/23
+              fm10_neutral, Diag%u10n, Diag%v10n, Sfcprop%rhoa)  ! Added by Sofar: 10/19/23
       !endif
 
       Tbd%phy_f2d(:,Model%num_p2d) = 0.0
@@ -3875,7 +3874,7 @@ module module_physics_driver
                        Sfcprop%f10m, Diag%u10m, Diag%v10m, Sfcprop%t2m, &
                        Sfcprop%q2m, work3, evap, Sfcprop%ffmm,          &
                        Sfcprop%ffhh, fm10, fh2, &
-                       fm10_neutral, Diag%u10n, Diag%v10n)  ! Added by Sofar: 10/19/23
+                       fm10_neutral, Diag%u10n, Diag%v10n, Sfcprop%rhoa)  ! Added by Sofar: 10/19/23
 
         if (Model%lssav) then
           Diag%tmpmax (:) = max(Diag%tmpmax (:),Sfcprop%t2m(:))

--- a/gsmphys/sfc_diag.f
+++ b/gsmphys/sfc_diag.f
@@ -1,19 +1,21 @@
       subroutine sfc_diag(im,ps,u1,v1,t1,q1,
      &                    tskin,qsurf,f10m,u10m,v10m,t2m,q2m,
      &                    prslki,evap,fm,fh,fm10,fh2,
-     &                    fm10_neutral,u10n,v10n)    ! Sofar added: 10/19/23
+     &                    fm10_neutral,u10n,v10n, rhoa)    ! Sofar added: 10/19/23
 !
       use machine , only : kind_phys
       use funcphys, only : fpvs
       use physcons, grav => con_g,  cp => con_cp,
-     &              eps => con_eps, epsm1 => con_epsm1
+     &              eps => con_eps, epsm1 => con_epsm1,
+     &              rvrdm1 => con_fvirt, rd => con_rd
+
       implicit none
 !
       integer              im
       real, dimension(im) :: ps,   u1,   v1,   t1,  q1,  tskin,  qsurf,
      &                       f10m, u10m, v10m, t2m, q2m, prslki, evap,
      &                       fm,   fh,   fm10, fh2, 
-     &                       fm10_neutral, u10n, v10n    ! Added by Sofar: 10/19/23
+     &                       fm10_neutral, u10n, v10n, rhoa    ! Added by Sofar: 10/19/23
 !
 !     locals
 !
@@ -60,6 +62,8 @@
         qss    = fpvs(t2m(i))
         qss    = eps * qss / (ps(i) + epsm1 * qss)
         q2m(i) = min(q2m(i),qss)
+        rhoa(i) = 
+     &  ps(i) / (rd * t2m(i) * (1.0 + rvrdm1 * max(q2m(i),1.e-8)))
       enddo
 
       return

--- a/gsmphys/sfc_diff_gfdl.f
+++ b/gsmphys/sfc_diff_gfdl.f
@@ -13,7 +13,6 @@
      &                    prsl1,prslki,islimsk,
      &                    stress,fm,fh,
      &                    charnock,                             ! Sofar added Spring 2023
-     &                    rhoa,                                 ! Sofar added 9/22/23
      &                    u10m_array,v10m_array,                ! Sofar added 11/17/23
      &                    u10n,v10n,                            ! Sofar added 9/22/23
      &                    fm10_neutral,                         ! Sofar added 10/19/23
@@ -43,7 +42,7 @@
      &,                                    prsl1, prslki, stress
      &,                                    fm, fh
      &,                                    charnock                     ! Sofar added Spring 2023
-     &,                                    rhoa, u10n, v10n             ! Sofar added 9/22/23
+     &,                                    u10n, v10n                   ! Sofar added 9/22/23
      &,                                    u10m_array, v10m_array       ! Sofar added 11/17/23
      &,                                    ustar, wind 
      &,                                    ddvel
@@ -66,7 +65,6 @@
      &                     hl1,    hl12,   pm,     ph,  pm10,  ph2, rat,
      &                     thv1,   tvs,    z1i,    z0, zt, z0max, ztmax,
      &                     fms,    fhs,    hl0,    hl0inf, hlinf,
-     &                     tv1,                                   ! Sofar added 9/22/23
      &                     hl110,  hlt,    hltinf, olinf,
      &                     restar, czilc,  tem1,   tem2,
      &                     u10m, v10m, ws10m, ws10m_moon,         !kgao
@@ -96,8 +94,6 @@
      &                + max(0.0, min(ddvel(i), 30.0)), 1.0)
           tem1    = 1.0 + rvrdm1 * max(q1(i),1.e-8)
           thv1    = t1(i) * prslki(i) * tem1
-          tv1     = t1(i) * tem1                        ! Sofar added 9/22/23
-          rhoa(i)   = prsl1(i) / (rd*tv1)               ! Sofar added 9/22/23
           tvs     = 0.5 * (tsurf(i)+tskin(i)) * tem1
           qs1     = fpvs(t1(i))
           qs1     = max(1.0e-8, eps * qs1 / (prsl1(i) + epsm1 * qs1))


### PR DESCRIPTION


**Description**

This moves the computation of the air density from the surface layer parameterization to the sfc_diag routine that handles the diagnostics. There, it is computed for the 2-m level. This will ensure that the density reflects well on the density jump at the water/air interface and ensures that it is independent of the height of the first model level.

Fixes # (issue)

**How Has This Been Tested?**
Not yet.

**Checklist:**

Please check all whether they apply or not
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
