### PR TITLE
Add tuning parameters for the similarity profiles of the surface layer

### DIFF
--- a/GFS_layer/GFS_physics_driver.F90
+++ b/GFS_layer/GFS_physics_driver.F90
@@ -1202,7 +1202,8 @@ module module_physics_driver
                  Sfcprop%ffmm,  Sfcprop%ffhh, Sfcprop%uustar,       &
                  wind,  Tbd%phy_f2d(1,Model%num_p2d), fm10, fh2,    &
                  sigmaf, vegtype, Sfcprop%shdmax, Model%ivegsrc,    &
-                 tsurf, flag_iter) !, Model%redrag, Model%z0s_max,     &
+                 tsurf, flag_iter, Model%alpha_stable, Model%alpha_unstable) 
+!                , Model%redrag, Model%z0s_max,     &
                  !Model%do_z0_moon, Model%do_z0_hwrf15,              &
                  !Model%do_z0_hwrf17, Model%do_z0_hwrf17_hwonly,     &
                  !Model%wind_th_hwrf)
@@ -1225,7 +1226,7 @@ module module_physics_driver
                  tsurf, flag_iter, Model%redrag, Model%z0s_max,     &
                  Model%do_z0_moon, Model%do_z0_hwrf15,              &
                  Model%do_z0_hwrf17, Model%do_z0_hwrf17_hwonly,     &
-                 Model%wind_th_hwrf)
+                 Model%wind_th_hwrf, Model%alpha_stable, Model%alpha_unstable)
             else
 ! GFS original sfc_diff modified by kgao 
             call sfc_diff (im,Statein%pgr, Statein%ugrs, Statein%vgrs,&

--- a/GFS_layer/GFS_physics_driver.F90
+++ b/GFS_layer/GFS_physics_driver.F90
@@ -1202,7 +1202,8 @@ module module_physics_driver
                  Sfcprop%ffmm,  Sfcprop%ffhh, Sfcprop%uustar,       &
                  wind,  Tbd%phy_f2d(1,Model%num_p2d), fm10, fh2,    &
                  sigmaf, vegtype, Sfcprop%shdmax, Model%ivegsrc,    &
-                 tsurf, flag_iter, Model%alpha_stable, Model%alpha_unstable) 
+                 tsurf, flag_iter,                                  &
+                 Model%alpha_stable, Model%alpha_unstable, Model%tune_ocean_surface_layer) 
 !                , Model%redrag, Model%z0s_max,     &
                  !Model%do_z0_moon, Model%do_z0_hwrf15,              &
                  !Model%do_z0_hwrf17, Model%do_z0_hwrf17_hwonly,     &
@@ -1226,7 +1227,8 @@ module module_physics_driver
                  tsurf, flag_iter, Model%redrag, Model%z0s_max,     &
                  Model%do_z0_moon, Model%do_z0_hwrf15,              &
                  Model%do_z0_hwrf17, Model%do_z0_hwrf17_hwonly,     &
-                 Model%wind_th_hwrf, Model%alpha_stable, Model%alpha_unstable)
+                 Model%wind_th_hwrf,                                &
+                 Model%alpha_stable, Model%alpha_unstable, Model%tune_ocean_surface_layer)
             else
 ! GFS original sfc_diff modified by kgao 
             call sfc_diff (im,Statein%pgr, Statein%ugrs, Statein%vgrs,&

--- a/GFS_layer/GFS_physics_driver.F90
+++ b/GFS_layer/GFS_physics_driver.F90
@@ -1712,7 +1712,8 @@ module module_physics_driver
                          Model%dspheat, dusfc1, dvsfc1, dtsfc1, dqsfc1, Diag%hpbl,&
                          gamt, gamq, dkt, kinver, Model%xkzm_m, Model%xkzm_h,     &
                          Model%xkzm_s, lprnt, ipr,                                &
-                         Model%xkzminv, Model%moninq_fac)
+                         Model%xkzminv, Model%moninq_fac, Model%alpha_stable,     &
+                         Model%alpha_unstable, Model%tune_ocean_surface_layer)
 !     if (lprnt)  write(0,*)' dtdtm=',(dtdt(ipr,k),k=1,15)
 !     if (lprnt)  write(0,*)' dqdtm=',(dqdt(ipr,k,1),k=1,15)
 
@@ -1734,7 +1735,9 @@ module module_physics_driver
                    Model%xkzm_ml, Model%xkzm_hl, Model%xkzm_mi, Model%xkzm_hi,  & 
                    Model%xkzm_s,  Model%xkzminv, Model%do_dk_hb19,              &
                    Model%xkzm_lim, Model%xkgdx,                                 &
-                   Model%rlmn, Model%rlmx, Model%cap_k0_land, dkt)
+                   Model%rlmn, Model%rlmx, Model%cap_k0_land, dkt,              &
+                   Model%alpha_stable, Model%alpha_unstable,                    &
+                   Model%tune_ocean_surface_layer)
 
              elseif (Model%isatmedmf == 1) then   
                 do i=1,im
@@ -1761,7 +1764,8 @@ module module_physics_driver
                        Model%xkzm_s, Model%xkzminv, Model%rlmx, Model%zolcru,       &
                        Model%cs0, Model%do_dk_hb19, Model%xkgdx,                    &
                        Model%dspfac, Model%bl_upfr, Model%bl_dnfr, dkt,             &
-                       flux_cg, flux_en) !cg as up and en as down
+                       flux_cg, flux_en, Model%alpha_stable, Model%alpha_unstable,  &
+                       Model%tune_ocean_surface_layer) !cg as up and en as down
         endif
 
         elseif (Model%ysupbl) then

--- a/GFS_layer/GFS_typedefs.F90
+++ b/GFS_layer/GFS_typedefs.F90
@@ -680,6 +680,8 @@ module GFS_typedefs
     logical              :: do_z0_hwrf17    !< flag for using z0 scheme in 2017 HWRF (kgao)
     logical              :: do_z0_hwrf17_hwonly !< flag for using z0 scheme in 2017 HWRF only under high wind (kgao)
     real(kind=kind_phys) :: wind_th_hwrf    !< wind speed threshold when z0 level off as in HWRF (kgao)
+    real(kind=kind_phys) :: alpha_stable    !< description TBD
+    real(kind=kind_phys) :: alpha_unstable  !< description TBD
     logical              :: hybedmf         !< flag for hybrid edmf pbl scheme
     logical              :: myj_pbl         !< flag for NAM MYJ tke scheme
     logical              :: ysupbl          !< flag for ysu pbl scheme (version in WRFV3.8)
@@ -2401,6 +2403,8 @@ end subroutine overrides_create
     logical              :: do_z0_hwrf17   = .false.                  !< flag for using z0 scheme in 2017 HWRF
     logical              :: do_z0_hwrf17_hwonly = .false.             !< flag for using z0 scheme in 2017 HWRF only under high wind
     real(kind=kind_phys) :: wind_th_hwrf   = 33.                      !< wind speed threshold when z0 level off as in HWRF
+    real(kind=kind_phys) :: alpha_stable   = 5.                       !< TBD
+    real(kind=kind_phys) :: alpha_unstable = 16.                      !< TBD
     logical              :: hybedmf        = .false.                  !< flag for hybrid edmf pbl scheme
     logical              :: myj_pbl        = .false.                  !< flag for NAM MYJ tke-based scheme
     logical              :: ysupbl         = .false.                  !< flag for hybrid edmf pbl scheme
@@ -2878,6 +2882,8 @@ end subroutine overrides_create
     Model%do_z0_hwrf17     = do_z0_hwrf17
     Model%do_z0_hwrf17_hwonly = do_z0_hwrf17_hwonly
     Model%wind_th_hwrf     = wind_th_hwrf
+    Model%alpha_stable     = alpha_stable
+    Model%alpha_unstable   = alpha_unstable
     Model%hybedmf          = hybedmf
     Model%myj_pbl          = myj_pbl
     Model%ysupbl           = ysupbl
@@ -3585,6 +3591,8 @@ end subroutine overrides_create
       print *, ' do_z0_hwrf17      : ', Model%do_z0_hwrf17
       print *, ' do_z0_hwrf17_hwonly : ', Model%do_z0_hwrf17_hwonly
       print *, ' wind_th_hwrf      : ', Model%wind_th_hwrf
+      print *, ' alpha_stable      : ', Model%alpha_stable
+      print *, ' alpha_unstable    : ', Model%alpha_unstable
       print *, ' hybedmf           : ', Model%hybedmf
       print *, ' myj_pbl           : ', Model%myj_pbl
       print *, ' ysupbl            : ', Model%ysupbl

--- a/GFS_layer/GFS_typedefs.F90
+++ b/GFS_layer/GFS_typedefs.F90
@@ -682,6 +682,7 @@ module GFS_typedefs
     real(kind=kind_phys) :: wind_th_hwrf    !< wind speed threshold when z0 level off as in HWRF (kgao)
     real(kind=kind_phys) :: alpha_stable    !< description TBD
     real(kind=kind_phys) :: alpha_unstable  !< description TBD
+    logical              :: tune_ocean_surface_layer !< if true, use alphas above to modify the SL similarity profiles over oceans
     logical              :: hybedmf         !< flag for hybrid edmf pbl scheme
     logical              :: myj_pbl         !< flag for NAM MYJ tke scheme
     logical              :: ysupbl          !< flag for ysu pbl scheme (version in WRFV3.8)
@@ -2405,6 +2406,7 @@ end subroutine overrides_create
     real(kind=kind_phys) :: wind_th_hwrf   = 33.                      !< wind speed threshold when z0 level off as in HWRF
     real(kind=kind_phys) :: alpha_stable   = 5.                       !< TBD
     real(kind=kind_phys) :: alpha_unstable = 16.                      !< TBD
+    logical              :: tune_ocean_surface_layer = .false.        !< if true, use alphas above to modify the SL similarity profiles over oceans
     logical              :: hybedmf        = .false.                  !< flag for hybrid edmf pbl scheme
     logical              :: myj_pbl        = .false.                  !< flag for NAM MYJ tke-based scheme
     logical              :: ysupbl         = .false.                  !< flag for hybrid edmf pbl scheme
@@ -2637,7 +2639,8 @@ end subroutine overrides_create
                                cscnv, cal_pre, do_aw, do_shoc, shocaftcnv, shoc_cld,        &
                                h2o_phys, pdfcld, shcnvcw, redrag, sfc_gfdl, z0s_max,        &
                                sfc_coupled, do_z0_moon, do_z0_hwrf15, do_z0_hwrf17,         &
-                               do_z0_hwrf17_hwonly, wind_th_hwrf,                           &
+                               do_z0_hwrf17_hwonly, wind_th_hwrf, alpha_stable,             &
+                               alpha_unstable, tune_ocean_surface_layer,                    &                                             &
                                hybedmf, dspheat, lheatstrg, hour_canopy, afac_canopy,       &
                                cnvcld, no_pbl, xkzm_lim, xkzm_fac, xkgdx,                   &
                                rlmn, rlmx, zolcru, cs0,                                     &
@@ -2884,6 +2887,7 @@ end subroutine overrides_create
     Model%wind_th_hwrf     = wind_th_hwrf
     Model%alpha_stable     = alpha_stable
     Model%alpha_unstable   = alpha_unstable
+    Model%tune_ocean_surface_layer = tune_ocean_surface_layer
     Model%hybedmf          = hybedmf
     Model%myj_pbl          = myj_pbl
     Model%ysupbl           = ysupbl
@@ -3593,6 +3597,7 @@ end subroutine overrides_create
       print *, ' wind_th_hwrf      : ', Model%wind_th_hwrf
       print *, ' alpha_stable      : ', Model%alpha_stable
       print *, ' alpha_unstable    : ', Model%alpha_unstable
+      print *, ' tune_ocean_surface_layer : ', Model%tune_ocean_surface_layer 
       print *, ' hybedmf           : ', Model%hybedmf
       print *, ' myj_pbl           : ', Model%myj_pbl
       print *, ' ysupbl            : ', Model%ysupbl

--- a/GFS_layer/GFS_typedefs.F90
+++ b/GFS_layer/GFS_typedefs.F90
@@ -2640,7 +2640,7 @@ end subroutine overrides_create
                                h2o_phys, pdfcld, shcnvcw, redrag, sfc_gfdl, z0s_max,        &
                                sfc_coupled, do_z0_moon, do_z0_hwrf15, do_z0_hwrf17,         &
                                do_z0_hwrf17_hwonly, wind_th_hwrf, alpha_stable,             &
-                               alpha_unstable, tune_ocean_surface_layer,                    &                                             &
+                               alpha_unstable, tune_ocean_surface_layer,                    &
                                hybedmf, dspheat, lheatstrg, hour_canopy, afac_canopy,       &
                                cnvcld, no_pbl, xkzm_lim, xkzm_fac, xkgdx,                   &
                                rlmn, rlmx, zolcru, cs0,                                     &

--- a/GFS_layer/GFS_typedefs.F90
+++ b/GFS_layer/GFS_typedefs.F90
@@ -680,9 +680,9 @@ module GFS_typedefs
     logical              :: do_z0_hwrf17    !< flag for using z0 scheme in 2017 HWRF (kgao)
     logical              :: do_z0_hwrf17_hwonly !< flag for using z0 scheme in 2017 HWRF only under high wind (kgao)
     real(kind=kind_phys) :: wind_th_hwrf    !< wind speed threshold when z0 level off as in HWRF (kgao)
-    real(kind=kind_phys) :: alpha_stable    !< description TBD
-    real(kind=kind_phys) :: alpha_unstable  !< description TBD
-    logical              :: tune_ocean_surface_layer !< if true, use alphas above to modify the SL similarity profiles over oceans
+    real(kind=kind_phys) :: alpha_stable    !< tuning parameter for the dimensionless momentum and scalar gradient function in the surface layer
+    real(kind=kind_phys) :: alpha_unstable  !< tuning parameter for the dimensionless momentum gradient function in the surface layer
+    logical              :: tune_ocean_surface_layer !< if true, use alphas above to modify the surface layer dimensionless gradients over oceans
     logical              :: hybedmf         !< flag for hybrid edmf pbl scheme
     logical              :: myj_pbl         !< flag for NAM MYJ tke scheme
     logical              :: ysupbl          !< flag for ysu pbl scheme (version in WRFV3.8)
@@ -2404,9 +2404,9 @@ end subroutine overrides_create
     logical              :: do_z0_hwrf17   = .false.                  !< flag for using z0 scheme in 2017 HWRF
     logical              :: do_z0_hwrf17_hwonly = .false.             !< flag for using z0 scheme in 2017 HWRF only under high wind
     real(kind=kind_phys) :: wind_th_hwrf   = 33.                      !< wind speed threshold when z0 level off as in HWRF
-    real(kind=kind_phys) :: alpha_stable   = 5.                       !< TBD
-    real(kind=kind_phys) :: alpha_unstable = 16.                      !< TBD
-    logical              :: tune_ocean_surface_layer = .false.        !< if true, use alphas above to modify the SL similarity profiles over oceans
+    real(kind=kind_phys) :: alpha_stable   = 5.                       !< tuning parameter for the dimensionless momentum and scalar gradient function in the surface layer
+    real(kind=kind_phys) :: alpha_unstable = 16.                      !< tuning parameter for the dimensionless momentum gradient function in the surface layer
+    logical              :: tune_ocean_surface_layer = .false.        !< if true, use alphas above to modify the surface layer dimensionless gradients over oceans
     logical              :: hybedmf        = .false.                  !< flag for hybrid edmf pbl scheme
     logical              :: myj_pbl        = .false.                  !< flag for NAM MYJ tke-based scheme
     logical              :: ysupbl         = .false.                  !< flag for hybrid edmf pbl scheme

--- a/gsmphys/moninedmf.f
+++ b/gsmphys/moninedmf.f
@@ -93,7 +93,8 @@
      &   prsi,del,prsl,prslk,phii,phil,delt,dspheat,                    &
      &   dusfc,dvsfc,dtsfc,dqsfc,hpbl,hgamt,hgamq,dkt,                  &
      &   kinver,xkzm_m,xkzm_h,xkzm_s,lprnt,ipr,                         &
-     &   xkzminv,moninq_fac)
+     &   xkzminv,moninq_fac, alpha_stable, alpha_unstable,              &
+     &   tune_ocean_surface_layer)
 !
       use machine  , only : kind_phys
       use funcphys , only : fpvs
@@ -103,11 +104,12 @@
 !
 !     arguments
 !
-      logical lprnt
+      logical lprnt, tune_ocean_surface_layer
       integer ipr
       integer ix, im, km, ntrac, ntcw, kpbl(im), kinver(im)
 !
-      real(kind=kind_phys) delt, xkzm_m, xkzm_h, xkzm_s
+      real(kind=kind_phys) delt, xkzm_m, xkzm_h, xkzm_s, alpha_stable, 
+     &    alpha_unstable
       real(kind=kind_phys) dv(im,km),     du(im,km),                    &
      &                     tau(im,km),    rtg(im,km,ntrac),             &
      &                     u1(ix,km),     v1(ix,km),                    &
@@ -512,24 +514,12 @@ c
 !!  \f[
 !!  w_s = (u_*^3 + 7\epsilon k w_*^3)^{1/3}
 !!  \f]
+      call get_similarity_parameters(im, rbsoil, fm, fh, rimin,
+     &  sfcflg, zfmin, sfcfrac, hpbl, zl(1:im,1), 
+     &  aphi16, aphi5, alpha_unstable, alpha_stable, 
+     &  tune_ocean_surface_layer, phim, phih, zol)
+
       do i=1,im
-         zol(i) = max(rbsoil(i)*fm(i)*fm(i)/fh(i),rimin)
-         if(sfcflg(i)) then
-           zol(i) = min(zol(i),-zfmin)
-         else
-           zol(i) = max(zol(i),zfmin)
-         endif
-         zol1 = zol(i)*sfcfrac*hpbl(i)/zl(i,1)
-         if(sfcflg(i)) then
-!          phim(i) = (1.-aphi16*zol1)**(-1./4.)
-!          phih(i) = (1.-aphi16*zol1)**(-1./2.)
-           tem     = 1.0 / (1. - aphi16*zol1)
-           phih(i) = sqrt(tem)
-           phim(i) = sqrt(phih(i))
-         else
-           phim(i) = 1. + aphi5*zol1
-           phih(i) = phim(i)
-         endif
          wscale(i) = ustar(i)/phim(i)
          ustmin(i) = ustar(i)/aphi5
          wscale(i) = max(wscale(i),ustmin(i))

--- a/gsmphys/satmedmfvdiff.f
+++ b/gsmphys/satmedmfvdiff.f
@@ -1578,10 +1578,10 @@ c-----------------------------------------------------------------------
 
       ! local 
       integer i
-      real(kind=kind_phys) :: zol1
+      real(kind=kind_phys) :: zol1, tem
         
         do i=1,im
-           zol(i) = max(rbsoilv*fm(i)*fm(i)/fh(i),rimin)
+           zol(i) = max(rbsoil(i)*fm(i)*fm(i)/fh(i),rimin)
            if(sfcflg(i)) then
              zol(i) = min(zol(i),-zfmin)
            else

--- a/gsmphys/satmedmfvdiff.f
+++ b/gsmphys/satmedmfvdiff.f
@@ -1578,7 +1578,7 @@ c-----------------------------------------------------------------------
 
       ! local 
       integer i
-      real :: zol1
+      real(kind=kind_phys) :: zol1
         
         do i=1,im
            zol(i) = max(rbsoilv*fm(i)*fm(i)/fh(i),rimin)

--- a/gsmphys/satmedmfvdiff.f
+++ b/gsmphys/satmedmfvdiff.f
@@ -36,7 +36,8 @@
      &     dspheat,dusfc,dvsfc,dtsfc,dqsfc,hpbl,
      &     kinver,xkzm_mo,xkzm_ho,xkzm_ml,xkzm_hl,xkzm_mi,xkzm_hi,
      &     xkzm_s,xkzinv,do_dk_hb19,xkzm_lim,xkgdx,
-     &     rlmn, rlmx, cap_k0_land, dkt_out)
+     &     rlmn, rlmx, cap_k0_land, dkt_out, 
+     &     alpha_stable, alpha_unstable, tune_ocean_surface_layer)
 !
       use machine  , only : kind_phys
       use funcphys , only : fpvs
@@ -53,7 +54,8 @@
 !
       real(kind=kind_phys) delt, xkzm_s, xkzm_lim,
      &                     xkzm_mo, xkzm_ho, xkzm_ml, xkzm_hl, 
-     &                     xkzm_mi, xkzm_hi
+     &                     xkzm_mi, xkzm_hi,
+     &                     alpha_stable, alpha_unstable
       real(kind=kind_phys) dv(im,km),     du(im,km),
      &                     tdt(im,km),    rtg(im,km,ntrac),
      &                     u1(ix,km),     v1(ix,km),
@@ -77,7 +79,7 @@
 ! kgao note - q1 and rtg are local var now
 
 !
-      logical dspheat, cap_k0_land, do_dk_hb19
+      logical dspheat, cap_k0_land, do_dk_hb19, tune_ocean_surface_layer
 !          flag for tke dissipative heating
       real(kind=kind_phys),dimension(1:im,1:km),intent(OUT)::dkt_out
 
@@ -592,24 +594,10 @@
 !
 !     compute similarity parameters
 !
-      do i=1,im
-         zol(i) = max(rbsoil(i)*fm(i)*fm(i)/fh(i),rimin)
-         if(sfcflg(i)) then
-           zol(i) = min(zol(i),-zfmin)
-         else
-           zol(i) = max(zol(i),zfmin)
-         endif
-!
-         zol1 = zol(i)*sfcfrac*hpbl(i)/zl(i,1)
-         if(sfcflg(i)) then
-           tem     = 1.0 / (1. - aphi16*zol1)
-           phih(i) = sqrt(tem)
-           phim(i) = sqrt(phih(i))
-         else
-           phim(i) = 1. + aphi5*zol1
-           phih(i) = phim(i)
-         endif
-      enddo
+      call get_similarity_parameters(im, rbsoil, fm, fh, rimin,
+     &  sfcflg, zfmin, sfcfrac, hpbl, zl(1:im,1), 
+     &  aphi16, aphi5, alpha_unstable, alpha_stable, 
+     &  tune_ocean_surface_layer, phim, phih, zol)
 !
       do i=1,im
         if(pblflg(i)) then
@@ -1564,3 +1552,61 @@ c-----------------------------------------------------------------------
 c-----------------------------------------------------------------------
       return
       end
+
+      subroutine get_similarity_parameters(
+     &  im, rbsoil, fm, fh, rimin,
+     &  sfcflg, zfmin, sfcfrac, hpbl, zl, 
+     &  aphi16, aphi5, alpha_unstable, alpha_stable, 
+     &  tune_ocean_surface_layer, phim, phih, zol
+     &  )
+
+      use machine, only : kind_phys
+
+      implicit none
+      ! input
+      integer, intent(in) :: im
+      real(kind=kind_phys), dimension(1:im), intent(in) ::
+     &  rbsoil, fm, fh, hpbl, zl
+      real(kind=kind_phys), intent(in) :: rimin, zfmin, aphi16, aphi5,
+     &  alpha_unstable, alpha_stable, sfcfrac
+      logical, dimension(1:im), intent(in) :: sfcflg
+      logical, intent(in) :: tune_ocean_surface_layer
+
+      ! output
+      real(kind=kind_phys), dimension(1:im), intent(out) ::  phim, phih,
+     &   zol 
+
+      ! local 
+      integer i
+      real :: zol1
+        
+        do i=1,im
+           zol(i) = max(rbsoilv*fm(i)*fm(i)/fh(i),rimin)
+           if(sfcflg(i)) then
+             zol(i) = min(zol(i),-zfmin)
+           else
+             zol(i) = max(zol(i),zfmin)
+           endif
+  !
+           zol1 = zol(i)*sfcfrac*hpbl(i)/zl(i)
+           if(sfcflg(i)) then
+             tem     = 1.0 / (1. - aphi16*zol1)
+             phih(i) = sqrt(tem)
+             if (tune_ocean_surface_layer) then
+              tem     = 1.0 / (1. - alpha_unstable*zol1)
+              phim(i) = sqrt(sqrt(tem))
+             else
+              phim(i) = sqrt(phih(i))
+             end if
+           else
+             if (tune_ocean_surface_layer) then 
+              phim(i) = 1. + alpha_stable*zol1
+             else
+              phim(i) = 1. + aphi5*zol1
+             end if
+             phih(i) = phim(i)
+           endif
+        enddo
+        return
+      end subroutine
+

--- a/gsmphys/satmedmfvdifq.f
+++ b/gsmphys/satmedmfvdifq.f
@@ -56,7 +56,8 @@
      &     kinver,xkzm_mo,xkzm_ho,xkzm_ml,xkzm_hl,xkzm_mi,xkzm_hi,
      &     xkzm_s,xkzinv,rlmx,zolcru,cs0,
      &     do_dk_hb19,xkgdx,dspfac,bl_upfr,bl_dnfr,dkt_out,
-     &     flux_up, flux_dn)
+     &     flux_up, flux_dn, 
+     &     alpha_stable, alpha_unstable, tune_ocean_surface_layer)
 !
       use machine  , only : kind_phys
       use funcphys , only : fpvs
@@ -73,7 +74,8 @@
 !
       real(kind=kind_phys) delt, xkzm_mo, xkzm_ho, xkzm_s, dspfac,
      &                     bl_upfr, bl_dnfr, xkzm_ml, xkzm_hl,
-     &                     xkzm_mi, xkzm_hi
+     &                     xkzm_mi, xkzm_hi, alpha_stable, 
+     &                     alpha_unstable
       real(kind=kind_phys) dv(im,km),     du(im,km),
      &                     tdt(im,km),    rtg(im,km,ntrac),
      &                     u1(ix,km),     v1(ix,km),
@@ -97,7 +99,7 @@
      &                     rtg_in(im,km,ntrac)
 ! kgao note - q1 and rtg are local var now 
 !
-      logical dspheat, do_dk_hb19
+      logical dspheat, do_dk_hb19, tune_ocean_surface_layer
 !          flag for tke dissipative heating
       real(kind=kind_phys)::dkt_out(im,km),flux_up(im,km),flux_dn(im,km)
 !
@@ -619,24 +621,10 @@
 !
 !     compute similarity parameters
 !
-      do i=1,im
-         zol(i) = max(rbsoil(i)*fm(i)*fm(i)/fh(i),rimin)
-         if(sfcflg(i)) then
-           zol(i) = min(zol(i),-zfmin)
-         else
-           zol(i) = max(zol(i),zfmin)
-         endif
-!
-         zol1 = zol(i)*sfcfrac*hpbl(i)/zl(i,1)
-         if(sfcflg(i)) then
-           tem     = 1.0 / (1. - aphi16*zol1)
-           phih(i) = sqrt(tem)
-           phim(i) = sqrt(phih(i))
-         else
-           phim(i) = 1. + aphi5*zol1
-           phih(i) = phim(i)
-         endif
-      enddo
+      call get_similarity_parameters(im, rbsoil, fm, fh, rimin,
+     &  sfcflg, zfmin, sfcfrac, hpbl, zl(1:im,1), 
+     &  aphi16, aphi5, alpha_unstable, alpha_stable, 
+     &  tune_ocean_surface_layer, phim, phih, zol)
 !
       do i=1,im
         if(pblflg(i)) then

--- a/gsmphys/sfc_diff_coupled.f
+++ b/gsmphys/sfc_diff_coupled.f
@@ -4,7 +4,8 @@
      &                    stress,fm,fh,
      &                    ustar,wind,ddvel,fm10,fh2,
      &                    sigmaf,vegtype,shdmax,ivegsrc,
-     &                    tsurf,flag_iter) !,redrag,
+     &                    tsurf,flag_iter, alpha_stable, alpha_unstable) 
+!                         ,redrag,
 !     &                    z0s_max)
 !     &                    do_z0_moon, do_z0_hwrf15, do_z0_hwrf17,
 !     &                    do_z0_hwrf17_hwonly, wind_th_hwrf)
@@ -26,7 +27,9 @@
      &,                                    prsl1, prslki, stress
      &,                                    fm, fh, ustar, wind, ddvel
      &,                                    fm10, fh2, sigmaf, shdmax
-     &,                                    tsurf, snwdph
+     &,                                    tsurf, snwdph, alpha_stable 
+     &,                                    alpha_unstable
+
       integer, dimension(im)             ::vegtype, islimsk
 
       logical   flag_iter(im)
@@ -143,7 +146,9 @@
 ! --- call similarity
 
             call monin_obukhov_similarity
-     &       (z1(i), snwdph(i), thv1, wind(i), z0max, ztmax, tvs,
+     &       (islimsk(i), z1(i), snwdph(i), thv1, wind(i), z0max, 
+     &        ztmax, tvs,
+     &        alpha_stable, alpha_unstable,
      &        rb(i), fm(i), fh(i), fm10(i), fh2(i),
      &        cm(i), ch(i), stress(i), ustar(i))
 
@@ -165,7 +170,9 @@
             ! --- call similarity
             ! kgao: use z0/zt to do sfc diagnosis
             call monin_obukhov_similarity
-     &       (z1(i), snwdph(i), thv1, wind(i), z0max, ztmax, tvs,
+     &       (islimsk(i), z1(i), snwdph(i), thv1, wind(i), z0max, 
+     &        ztmax, tvs,
+     &        alpha_stable, alpha_unstable,
      &        rb(i), fm(i), fh(i), fm10(i), fh2(i),
      &        cm(i), ch(i), tem1, tem2) !stress(i), ustar(i))
 

--- a/gsmphys/sfc_diff_coupled.f
+++ b/gsmphys/sfc_diff_coupled.f
@@ -4,7 +4,8 @@
      &                    stress,fm,fh,
      &                    ustar,wind,ddvel,fm10,fh2,
      &                    sigmaf,vegtype,shdmax,ivegsrc,
-     &                    tsurf,flag_iter, alpha_stable, alpha_unstable) 
+     &                    tsurf,flag_iter, alpha_stable, alpha_unstable,
+     &                    tune_ocean_surface_layer) 
 !                         ,redrag,
 !     &                    z0s_max)
 !     &                    do_z0_moon, do_z0_hwrf15, do_z0_hwrf17,
@@ -32,7 +33,7 @@
 
       integer, dimension(im)             ::vegtype, islimsk
 
-      logical   flag_iter(im)
+      logical   flag_iter(im), tune_ocean_surface_layer
 !      logical   redrag        
 !      logical   do_z0_moon, do_z0_hwrf15, do_z0_hwrf17 ! kgao 
 !     &,         do_z0_hwrf17_hwonly                    ! kgao 
@@ -148,7 +149,7 @@
             call monin_obukhov_similarity
      &       (islimsk(i), z1(i), snwdph(i), thv1, wind(i), z0max, 
      &        ztmax, tvs,
-     &        alpha_stable, alpha_unstable,
+     &        alpha_stable, alpha_unstable, tune_ocean_surface_layer,
      &        rb(i), fm(i), fh(i), fm10(i), fh2(i),
      &        cm(i), ch(i), stress(i), ustar(i))
 
@@ -172,7 +173,7 @@
             call monin_obukhov_similarity
      &       (islimsk(i), z1(i), snwdph(i), thv1, wind(i), z0max, 
      &        ztmax, tvs,
-     &        alpha_stable, alpha_unstable,
+     &        alpha_stable, alpha_unstable, tune_ocean_surface_layer,
      &        rb(i), fm(i), fh(i), fm10(i), fh2(i),
      &        cm(i), ch(i), tem1, tem2) !stress(i), ustar(i))
 

--- a/gsmphys/sfc_diff_gfdl.f
+++ b/gsmphys/sfc_diff_gfdl.f
@@ -23,7 +23,8 @@
      &                    z0s_max,
      &                    do_z0_moon, do_z0_hwrf15, do_z0_hwrf17,
      &                    do_z0_hwrf17_hwonly, wind_th_hwrf, 
-     &                    alpha_stable, alpha_unstable)
+     &                    alpha_stable, alpha_unstable,
+     &                    tune_ocean_surface_layer)
 
 ! oct 2019 - a clean and updated version by Kun Gao at GFDL (Kun.Gao@noaa.gov)
 
@@ -54,7 +55,7 @@
       real(kind=kind_phys) :: ws1, ws10n, alpha_stable, alpha_unstable  ! Sofar added 10/19/23
       integer, dimension(im)             ::vegtype, islimsk
 
-      logical   flag_iter(im)
+      logical   flag_iter(im), tune_ocean_surface_layer
       logical   redrag        
       logical   do_z0_moon, do_z0_hwrf15, do_z0_hwrf17 ! kgao 
      &,         do_z0_hwrf17_hwonly                    ! kgao 
@@ -174,7 +175,7 @@
             call monin_obukhov_similarity
      &       (islimsk(i), z1(i), snwdph(i), thv1, wind(i), z0max,
      &        ztmax, tvs,
-     &        alpha_stable, alpha_unstable,
+     &        alpha_stable, alpha_unstable, tune_ocean_surface_layer,
      &        rb(i), fm(i), fh(i), fm10(i), fh2(i),
      &        fm_neutral(i), fm10_neutral(i),                          !(ADDED by Sofar)
      &        cm(i), ch(i), stress(i), ustar(i))
@@ -207,7 +208,7 @@
             call monin_obukhov_similarity
      &       (islimsk(i), z1(i), snwdph(i), thv1, wind(i), z0max,
      &        ztmax, tvs,
-     &        alpha_stable, alpha_unstable,
+     &        alpha_stable, alpha_unstable, tune_ocean_surface_layer,
      &        rb(i), fm(i), fh(i), fm10(i), fh2(i),
      &        fm_neutral(i), fm10_neutral(i),                          !(ADDED by Sofar)
      &        cm(i), ch(i), stress(i), ustar(i))
@@ -309,7 +310,7 @@
             call monin_obukhov_similarity
      &       (islimsk(i), z1(i), snwdph(i), thv1, wind(i), z0max,
      &        ztmax, tvs,
-     &        alpha_stable, alpha_unstable,
+     &        alpha_stable, alpha_unstable, tune_ocean_surface_layer,
      &        rb(i), fm(i), fh(i), fm10(i), fh2(i),
      &        fm_neutral(i), fm10_neutral(i),                          !(ADDED by Sofar)
      &        cm(i), ch(i), stress(i), ustar(i))
@@ -516,7 +517,7 @@
 
       subroutine monin_obukhov_similarity
      &     ( ilsimask, z1, snwdph, thv1, wind, z0max, ztmax, tvs,
-     &       alpha_stable, alpha_unstable,
+     &       alpha_stable, alpha_unstable, tune_ocean_surface_layer,
      &       rb, fm, fh, fm10, fh2,
      &       fm_neutral, fm10_neutral,                                 !(ADDED by Sofar)
      &       cm, ch, stress, ustar)
@@ -548,6 +549,7 @@
      &       alpha_unstable
 
       integer, intent(in) :: ilsimask
+      logical, intent(in) :: tune_ocean_surface_layer
 
 !  ---  outputs:
       real(kind=kind_phys), intent(out) ::
@@ -573,7 +575,7 @@
 
           z1i = 1.0 / z1
 
-          if (ilsimask == 0) then
+          if (ilsimask == 0 .and. tune_ocean_surface_layer) then
             alpha4 = alpha4_ocean
           else
             alpha4 = alpha4_nonocean
@@ -665,7 +667,7 @@
               hl1   = hlinf
               hl110 = hl1 * 10. * z1i
               hl110 = min(max(hl110, ztmin1), ztmax1)
-              if (ilsimask == 0) then
+              if (ilsimask == 0 .and. tune_ocean_surface_layer) then
                 call get_psim_unstable(hlinf, z1i, z0max,
      &                                 alpha_unstable, pm)
                 call get_psim_unstable(hl110, 1./10., z0max,
@@ -684,7 +686,7 @@
               hl110 = hl1 * 10. * z1i
               hl110 = min(max(hl110, ztmin1), ztmax1)
               tem1  = 1.0 / sqrt(hl1)
-              if (ilsimask == 0) then
+              if (ilsimask == 0 .and. tune_ocean_surface_layer) then
                 call get_psim_unstable(hlinf, z1i, z0max,
      &                                 alpha_unstable, pm)
                 call get_psim_unstable(-hl110, 1./10., z0max,

--- a/gsmphys/sfc_diff_gfdl.f
+++ b/gsmphys/sfc_diff_gfdl.f
@@ -523,11 +523,16 @@
      &       cm, ch, stress, ustar)
 
 ! --- input 
+! ilsimask - land/sea/ice mask
 ! z1     - lowest model level height 
 ! snwdph - surface snow thickness 
 ! wind   - wind speed at lowest model layer
 ! thv1   - virtual potential temp at lowest model layer
 ! tvs    - surface temp
+! alpha_stable - tuning parameter (inverse crit. Richarson number) in dimensinless shear
+!                and scalar gradient; stable case
+! alpha_unstable - tuning parameter in dimensionless wind shear; unstable case
+! tune_ocean_surface_layer - if true, use alphas to tune surface layer over oceans
 ! z0max  - surface roughness length for momentum
 ! ztmax  - surface roughness length for heat
 !

--- a/gsmphys/sfc_diff_gfdl.f
+++ b/gsmphys/sfc_diff_gfdl.f
@@ -741,6 +741,6 @@
         Rz = (1. - alpha * zeta)**0.25
         R0 = (1. - alpha * zeta0)**0.25
         psi_m = log((1. + Rz)**2. * (1. + Rz**2.) / ((1. + R0)**2.
-     &  *(1. + R0**2.))) + 2. * np.arctan(R0) - 2. * np.arctan(Rz)
+     &  *(1. + R0**2.))) + 2. * atan(R0) - 2. * atan(Rz)
         return
       end subroutine

--- a/gsmphys/sfc_diff_gfdl.f
+++ b/gsmphys/sfc_diff_gfdl.f
@@ -566,7 +566,6 @@
 
       real(kind=kind_phys), parameter :: alpha=5., a0=-3.975
      &,             a1=12.32, alpha4_nonocean=4.0*alpha 
-     &,             alpha4_ocean = 4.*alpha_stable
      &,             b1=-7.755,  b2=6.041,  alpha2=alpha+alpha, beta=1.0
      &,             a0p=-7.941, a1p=24.75, b1p=-8.705, b2p=7.899
      &,             ztmin1=-999.0, ca=.4
@@ -581,7 +580,7 @@
           z1i = 1.0 / z1
 
           if (ilsimask == 0 .and. tune_ocean_surface_layer) then
-            alpha4 = alpha4_ocean
+            alpha4 = 4. * alpha_stable
           else
             alpha4 = alpha4_nonocean
           end if


### PR DESCRIPTION
**Description**

This PR adds two tuning parameters, one to tune the surface layer parameterization during stable, and one to tune it during unstable conditions. The default values correspond to the original formulation. These two parameters have an effect only over water surfaces when the land/sea/ice mask takes a value of 0 and when tune_ocean_surface_layer=True. Otherwise, the standard parameterization is used and the tuning parameters have no effect.

For consistency, these same modified profiles are also used in the PBL schemes satmedmfvdiff, satmedmfvdiffq, and moninedmf.

The design of these tuning coefficient is as follows:

- Stable regime: The original formulation is a linear function of stability. The slope of this empirical fit corresponds to the inverse of the critical Richardson number and is per default set to 5 for both momentum and scalars. Based on measurement campaigns this slope - named alpha_stable in the code - may take on a value in the range of about [4-10] (see Hogstrom (1988) and Long (1986)). A larger value implies a smaller critical Richardson number, thus less turbulent drag. The tuning parameter sets the slope for both momentum and scalars to maintain a Prandtl number of one.
- Unstable regime: The original formulation of the dimensionless gradient of momentum follows a (1-alpha*Zeta)**-0.25 law, whereby alpha is 16 following Dyer (1974) and Hicks (1976). The formulation for the gradient for scalars is the square root of it. Note that a numerical approximation is implemented (see Eqs. 2.37 and 2.64 in Long (1990)) that is baed on alpha=16. If tune_ocean_surface_layer=True, the gradient for momentum is computed on the unapproximated form (see Eq. 2.19 in Long (1990) (with fixed signs)) which differs slightly from the approximation even for alpha=16 of instabilities are very large. Per design, the Prandtl number, ratio of gradient of heat to momentum, is one for neutral conditions and drops down to around 0.4 for largely unstable conditions. Various measurement campaigns came up with different values for alpha (see Hogstrom, 1988) and the range roughly spans [10, 30]. Note that the Prandtl number is largely determined by the different exponents used in the momentum versus heat gradients, rather than by the value of alpha used in each. On top of this, other empirical formulations use separate values for alpha for momentum and heat. For this reason, the tuning variable added here only affects the alpha used in the dimensionless gradient of momentum.

References:
-Dyer, 1974: A review of flux-profile relations. Bound. Layer Meteor., 7, 363-372.
-Hicks, 1976: Wind profile relationships from the Wangara experiment. QJRMS, 102, 535-551.
-Hogstrom, 1988: Non-dimensional wind and temperature profiles in the atmospheric surface layer: A re-evaluation. Boundary-Layer Meteorol., 42, 55-78.
-Long, 1986: An economical and compatible scheme for parameterizing the stable surface layer in the medium range forecast model. Office note 321, NOAA.
-Long, 1990: Derivation and suggested method of the application of simplified relations for the surface fluxes in the medium-range forecast model: Unstable case. Office note 356, NOAA.


**How Has This Been Tested?**
No.

**Checklist:**

Please check all whether they apply or not
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
